### PR TITLE
Fix link to vertx-launcher-application docs

### DIFF
--- a/asciidoc/modules/cli_framework_deprecation.adoc
+++ b/asciidoc/modules/cli_framework_deprecation.adoc
@@ -25,7 +25,7 @@ Beware it is not guaranteed that backward compatibility can be maintained for th
 
 == Vert.x Application Launcher
 
-In {VertX} {v5}, a new module, the https://vertx.io/docs/vertx-application-launcher/java/[Vert.x Application Launcher] replaces the {VertX} {v4x} `io.vertx.core.Launcher` class.
+In {VertX} {v5}, a new module, the https://vertx.io/docs/vertx-launcher-application/java/[Vert.x Application Launcher] replaces the {VertX} {v4x} `io.vertx.core.Launcher` class.
 
 First, you must add it to your project's dependencies (Maven):
 


### PR DESCRIPTION
Motivation:

Explain here the context.

* The affected context is when someone reads the application launcher section: https://vertx.io/docs/guides/vertx-5-migration-guide/#_vert_x_application_launcher This is a section of the Vert.x 5 migration guide that people use to migrate from version 4 to version 5 of Vert.x.

Explain why you're making that change.

* The correct link is https://vertx.io/docs/vertx-launcher-application/java/

Explain what is the problem you're trying to solve.

* The section contains a dead link that, when clicked, results in a 404 error: https://vertx.io/docs/vertx-application-launcher/java/

Conformance:

* [x] You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
* [x] Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
